### PR TITLE
shareable mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This repository contains a set of tests to evaluate and compare the compatibilit
 
 |                             Gateway                             | Compatibility |  Test Cases  | Test Suites |
 | :-------------------------------------------------------------: | :-----------: | :----------: | :---------: |
-| [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) |    100.00%    |    🟢 187    |    🟢 41    |
-|         [Apollo Router](https://www.apollographql.com/)         |    97.86%     | 🟢 183 ❌ 4  | 🟢 39 ❌ 2  |
-|        [Apollo Gateway](https://www.apollographql.com/)         |    97.33%     | 🟢 182 ❌ 5  | 🟢 38 ❌ 3  |
-|             [Cosmo Router](https://wundergraph.com)             |    95.19%     | 🟢 178 ❌ 9  | 🟢 36 ❌ 5  |
-|            [Grafbase Gateway](https://grafbase.com)             |    90.91%     | 🟢 170 ❌ 17 | 🟢 35 ❌ 6  |
-|                [Inigo Gateway](https://inigo.io)                |    48.66%     | 🟢 91 ❌ 96  | 🟢 12 ❌ 29 |
+| [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) |    100.00%    |    🟢 188    |    🟢 41    |
+|         [Apollo Router](https://www.apollographql.com/)         |    97.87%     | 🟢 184 ❌ 4  | 🟢 39 ❌ 2  |
+|        [Apollo Gateway](https://www.apollographql.com/)         |    97.34%     | 🟢 183 ❌ 5  | 🟢 38 ❌ 3  |
+|             [Cosmo Router](https://wundergraph.com)             |    95.21%     | 🟢 179 ❌ 9  | 🟢 36 ❌ 5  |
+|            [Grafbase Gateway](https://grafbase.com)             |    90.43%     | 🟢 170 ❌ 18 | 🟢 34 ❌ 7  |
+|                [Inigo Gateway](https://inigo.io)                |    48.94%     | 🟢 92 ❌ 96  | 🟢 12 ❌ 29 |
 
 <!-- gateways:end -->
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -4,12 +4,12 @@
 
 |                             Gateway                             | Compatibility |  Test Cases  | Test Suites |
 | :-------------------------------------------------------------: | :-----------: | :----------: | :---------: |
-| [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) |    100.00%    |    🟢 187    |    🟢 41    |
-|         [Apollo Router](https://www.apollographql.com/)         |    97.86%     | 🟢 183 ❌ 4  | 🟢 39 ❌ 2  |
-|        [Apollo Gateway](https://www.apollographql.com/)         |    97.33%     | 🟢 182 ❌ 5  | 🟢 38 ❌ 3  |
-|             [Cosmo Router](https://wundergraph.com)             |    95.19%     | 🟢 178 ❌ 9  | 🟢 36 ❌ 5  |
-|            [Grafbase Gateway](https://grafbase.com)             |    90.91%     | 🟢 170 ❌ 17 | 🟢 35 ❌ 6  |
-|                [Inigo Gateway](https://inigo.io)                |    48.66%     | 🟢 91 ❌ 96  | 🟢 12 ❌ 29 |
+| [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) |    100.00%    |    🟢 188    |    🟢 41    |
+|         [Apollo Router](https://www.apollographql.com/)         |    97.87%     | 🟢 184 ❌ 4  | 🟢 39 ❌ 2  |
+|        [Apollo Gateway](https://www.apollographql.com/)         |    97.34%     | 🟢 183 ❌ 5  | 🟢 38 ❌ 3  |
+|             [Cosmo Router](https://wundergraph.com)             |    95.21%     | 🟢 179 ❌ 9  | 🟢 36 ❌ 5  |
+|            [Grafbase Gateway](https://grafbase.com)             |    90.43%     | 🟢 170 ❌ 18 | 🟢 34 ❌ 7  |
+|                [Inigo Gateway](https://inigo.io)                |    48.94%     | 🟢 92 ❌ 96  | 🟢 12 ❌ 29 |
 
 ## Detailed Results
 
@@ -57,7 +57,7 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <a href="./src/test-suites/keys-mashup">keys-mashup</a>
 <pre>🟢</pre>
 <a href="./src/test-suites/mutations">mutations</a>
-<pre>🟢🟢🟢</pre>
+<pre>🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/mysterious-external">mysterious-external</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/nested-provides">nested-provides</a>
@@ -150,7 +150,7 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <a href="./src/test-suites/keys-mashup">keys-mashup</a>
 <pre>❌</pre>
 <a href="./src/test-suites/mutations">mutations</a>
-<pre>🟢🟢🟢</pre>
+<pre>🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/mysterious-external">mysterious-external</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/nested-provides">nested-provides</a>
@@ -243,7 +243,7 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <a href="./src/test-suites/keys-mashup">keys-mashup</a>
 <pre>❌</pre>
 <a href="./src/test-suites/mutations">mutations</a>
-<pre>🟢🟢🟢</pre>
+<pre>🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/mysterious-external">mysterious-external</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/nested-provides">nested-provides</a>
@@ -336,7 +336,7 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <a href="./src/test-suites/keys-mashup">keys-mashup</a>
 <pre>🟢</pre>
 <a href="./src/test-suites/mutations">mutations</a>
-<pre>🟢🟢🟢</pre>
+<pre>🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/mysterious-external">mysterious-external</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/nested-provides">nested-provides</a>
@@ -429,7 +429,7 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <a href="./src/test-suites/keys-mashup">keys-mashup</a>
 <pre>🟢</pre>
 <a href="./src/test-suites/mutations">mutations</a>
-<pre>🟢🟢🟢</pre>
+<pre>🟢🟢🟢❌</pre>
 <a href="./src/test-suites/mysterious-external">mysterious-external</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/nested-provides">nested-provides</a>
@@ -522,7 +522,7 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <a href="./src/test-suites/keys-mashup">keys-mashup</a>
 <pre>❌</pre>
 <a href="./src/test-suites/mutations">mutations</a>
-<pre>🟢🟢❌</pre>
+<pre>🟢🟢❌🟢</pre>
 <a href="./src/test-suites/mysterious-external">mysterious-external</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/nested-provides">nested-provides</a>

--- a/gateways/apollo-gateway/results.txt
+++ b/gateways/apollo-gateway/results.txt
@@ -29,7 +29,7 @@ interface-object-with-requires
 keys-mashup
 X
 mutations
-...
+....
 mysterious-external
 ..
 nested-provides
@@ -82,6 +82,6 @@ union-intersection
 ............
 
 ---
-Total: 187
-Passed: 182
+Total: 188
+Passed: 183
 Failed: 5

--- a/gateways/apollo-router/results.txt
+++ b/gateways/apollo-router/results.txt
@@ -29,7 +29,7 @@ interface-object-with-requires
 keys-mashup
 X
 mutations
-...
+....
 mysterious-external
 ..
 nested-provides
@@ -82,6 +82,6 @@ union-intersection
 ............
 
 ---
-Total: 187
-Passed: 183
+Total: 188
+Passed: 184
 Failed: 4

--- a/gateways/cosmo-router/install.sh
+++ b/gateways/cosmo-router/install.sh
@@ -8,7 +8,7 @@ set -u
 BINARY_DOWNLOAD_PREFIX="https://github.com/wundergraph/cosmo/releases/download"
 
 # https://github.com/wundergraph/cosmo/releases
-DOWNLOAD_VERSION="0.220.0"
+DOWNLOAD_VERSION="0.222.1"
 
 download_binary() {
     downloader --check

--- a/gateways/cosmo-router/results.txt
+++ b/gateways/cosmo-router/results.txt
@@ -29,7 +29,7 @@ interface-object-with-requires
 keys-mashup
 .
 mutations
-...
+....
 mysterious-external
 ..
 nested-provides
@@ -82,6 +82,6 @@ union-intersection
 ............
 
 ---
-Total: 187
-Passed: 178
+Total: 188
+Passed: 179
 Failed: 9

--- a/gateways/grafbase-gateway/results.txt
+++ b/gateways/grafbase-gateway/results.txt
@@ -29,7 +29,7 @@ interface-object-with-requires
 keys-mashup
 .
 mutations
-...
+...X
 mysterious-external
 ..
 nested-provides
@@ -82,6 +82,6 @@ union-intersection
 ........X..X
 
 ---
-Total: 187
+Total: 188
 Passed: 170
-Failed: 17
+Failed: 18

--- a/gateways/hive-gateway/results.txt
+++ b/gateways/hive-gateway/results.txt
@@ -29,7 +29,7 @@ interface-object-with-requires
 keys-mashup
 .
 mutations
-...
+....
 mysterious-external
 ..
 nested-provides
@@ -82,6 +82,6 @@ union-intersection
 ............
 
 ---
-Total: 187
-Passed: 187
+Total: 188
+Passed: 188
 Failed: 0

--- a/gateways/inigo-gateway/results.txt
+++ b/gateways/inigo-gateway/results.txt
@@ -29,7 +29,7 @@ XXXXXXX
 keys-mashup
 X
 mutations
-..X
+..X.
 mysterious-external
 ..
 nested-provides
@@ -82,6 +82,6 @@ union-intersection
 XXXXXXXXX.XX
 
 ---
-Total: 187
-Passed: 91
+Total: 188
+Passed: 92
 Failed: 96

--- a/src/test-suites/mutations/data.ts
+++ b/src/test-suites/mutations/data.ts
@@ -4,11 +4,21 @@ interface Product {
   price: number;
 }
 
+interface Category {
+  id: string;
+  name: string;
+}
+
 let products: Product[] = [];
+let categories: Category[] = [];
 const numbers: Record<string, number> = {};
 
 export async function getProducts(): Promise<Product[]> {
   return products;
+}
+
+export function getCategories(): Category[] {
+  return categories;
 }
 
 export async function addProduct(name: string, price: number) {
@@ -19,6 +29,19 @@ export async function addProduct(name: string, price: number) {
   };
   products.push(newProduct);
   return newProduct;
+}
+
+export async function addCategory(name: string, requestId: string) {
+  if (categories.some((c) => c.id === "c-added-" + requestId)) {
+    throw new Error("Category with this requestId was already added");
+  }
+
+  const newCategory = {
+    id: "c-added-" + requestId,
+    name: name,
+  };
+  categories.push(newCategory);
+  return newCategory;
 }
 
 export async function deleteProduct(id: string) {

--- a/src/test-suites/mutations/test.ts
+++ b/src/test-suites/mutations/test.ts
@@ -71,5 +71,24 @@ export default () => {
         },
       },
     ),
+    // shared-root (mutation)
+    createTest(
+      /* GraphQL */ `
+        mutation {
+          addCategory(name: "new", requestId: "${randomId}") {
+            id
+            name
+          }
+        }
+      `,
+      {
+        data: {
+          addCategory: {
+            id: "c-added-" + randomId,
+            name: "new",
+          },
+        },
+      },
+    ),
   ];
 };

--- a/website/data.json
+++ b/website/data.json
@@ -2,8 +2,8 @@
   {
     "name": "Hive Gateway",
     "cases": {
-      "total": 187,
-      "passed": 187,
+      "total": 188,
+      "passed": 188,
       "failed": 0
     },
     "suites": {
@@ -15,8 +15,8 @@
   {
     "name": "Apollo Router",
     "cases": {
-      "total": 187,
-      "passed": 183,
+      "total": 188,
+      "passed": 184,
       "failed": 4
     },
     "suites": {
@@ -28,8 +28,8 @@
   {
     "name": "Apollo Gateway",
     "cases": {
-      "total": 187,
-      "passed": 182,
+      "total": 188,
+      "passed": 183,
       "failed": 5
     },
     "suites": {
@@ -41,8 +41,8 @@
   {
     "name": "Cosmo Router",
     "cases": {
-      "total": 187,
-      "passed": 178,
+      "total": 188,
+      "passed": 179,
       "failed": 9
     },
     "suites": {
@@ -54,21 +54,21 @@
   {
     "name": "Grafbase Gateway",
     "cases": {
-      "total": 187,
+      "total": 188,
       "passed": 170,
-      "failed": 17
+      "failed": 18
     },
     "suites": {
       "total": 41,
-      "passed": 35,
-      "failed": 6
+      "passed": 34,
+      "failed": 7
     }
   },
   {
     "name": "Inigo Gateway",
     "cases": {
-      "total": 187,
-      "passed": 91,
+      "total": 188,
+      "passed": 92,
       "failed": 96
     },
     "suites": {

--- a/website/index.html
+++ b/website/index.html
@@ -242,7 +242,7 @@
                     </td>
                     <td class="p-4 align-middle font-semibold">100.00%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 187</span>
+                      <span class="text-emerald-700 mr-2">✓ 188</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 41</span>
@@ -268,9 +268,9 @@
                         Apollo Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">97.86%</td>
+                    <td class="p-4 align-middle font-semibold">97.87%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 183</span>
+                      <span class="text-emerald-700 mr-2">✓ 184</span>
                       <span class="text-red-700">✗ 4</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -298,9 +298,9 @@
                         Apollo Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">97.33%</td>
+                    <td class="p-4 align-middle font-semibold">97.34%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 182</span>
+                      <span class="text-emerald-700 mr-2">✓ 183</span>
                       <span class="text-red-700">✗ 5</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -328,9 +328,9 @@
                         Cosmo Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">95.19%</td>
+                    <td class="p-4 align-middle font-semibold">95.21%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 178</span>
+                      <span class="text-emerald-700 mr-2">✓ 179</span>
                       <span class="text-red-700">✗ 9</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -358,14 +358,14 @@
                         Grafbase Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">90.91%</td>
+                    <td class="p-4 align-middle font-semibold">90.43%</td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 170</span>
-                      <span class="text-red-700">✗ 17</span>
+                      <span class="text-red-700">✗ 18</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 35</span>
-                      <span class="text-red-700">✗ 6</span>
+                      <span class="text-emerald-700 mr-2">✓ 34</span>
+                      <span class="text-red-700">✗ 7</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -388,9 +388,9 @@
                         Inigo Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">48.66%</td>
+                    <td class="p-4 align-middle font-semibold">48.94%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 91</span>
+                      <span class="text-emerald-700 mr-2">✓ 92</span>
                       <span class="text-red-700">✗ 96</span>
                     </td>
                     <td class="p-4 align-middle">


### PR DESCRIPTION
Similar to the `shared-root` test. It ensures mutation is ran through a single mutation field of a single subgraph, even though it's shareable and it's "cheaper" to collect two fields from two subgraphs using the shareable root field.